### PR TITLE
Production ready code for UIKit in SwiftUI

### DIFF
--- a/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
+++ b/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
@@ -18,10 +18,15 @@ struct SwiftUIwithUIKitView: View {
 //                    $0.text = "Hello no \(self.integer) from UIKit"
 //                }
 //                .fixedSize()
+                UIViewContainer(UILabel(), layout: .intrinsic)
+                    .set(\.text, to: "Hello, UIKit \(integer)!")
+                    .set(\.backgroundColor, to: UIColor(named: "swiftlee_orange"))
+//                    .fixedSize()
                 UIViewContainer(UIKitView(), layout: .intrinsic)
                     .set(\.title, to: "Hello, UIKit \(integer)!")
                     .set(\.backgroundColor, to: UIColor(named: "swiftlee_orange"))
                     .fixedSize()
+//                    .fixedSize()
                     .navigationTitle("Use UIKit in SwiftUI")
                 Button("RANDOMIZED: \(integer)") {
                     integer = Int.random(in: 0..<300)

--- a/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
+++ b/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
@@ -14,20 +14,13 @@ struct SwiftUIwithUIKitView: View {
     var body: some View {
         NavigationView {
             VStack {
-//                UIViewMaker<UILabel> {
-//                    $0.text = "Hello no \(self.integer) from UIKit"
-//                }
-//                .fixedSize()
-//                UIViewContainer(UILabel(), layout: .intrinsic)
-//                    .set(\.text, to: "Hello, UIKit \(integer)!")
-//                    .set(\.backgroundColor, to: UIColor(named: "swiftlee_orange"))
-//                    .fixedSize()
+                // Use UIKit inside SwiftUI like this:
                 UIViewContainer(UIKitView(), layout: .intrinsic)
                     .set(\.title, to: "Hello, UIKit \(integer)!")
                     .set(\.backgroundColor, to: UIColor(named: "swiftlee_orange"))
                     .fixedSize()
-//                    .fixedSize()
                     .navigationTitle("Use UIKit in SwiftUI")
+
                 Button("RANDOMIZED: \(integer)") {
                     integer = Int.random(in: 0..<300)
                 }
@@ -53,52 +46,3 @@ struct UILabelExample_Preview: PreviewProvider {
             .previewDisplayName("UILabel Preview Example")
     }
 }
-
-struct UIViewMaker<ViewType: UIView>: UIViewRepresentable {
-
-    typealias UIViewType = ViewType
-
-    var make: () -> ViewType = ViewType.init
-    var update: (ViewType) -> ()
-
-    func makeUIView(context: Context) -> ViewType {
-        return make()
-    }
-
-    func updateUIView(_ uiView: ViewType, context: Context) {
-        update(uiView)
-    }
-}
-
-struct ContentView: View {
-    @State var counter = 0
-
-    var body: some View {
-        VStack {
-
-            Text("Hello no \(counter) from SwiftUI")
-                .padding()
-
-
-            UIViewMaker<UILabel> {
-                $0.text = "Hello no \(self.counter) from UIKit"
-            }
-            .fixedSize()
-
-        }
-        .onAppear {
-            if counter == 0 {
-                schedule()
-            }
-        }
-    }
-
-    func schedule() {
-        counter += 1
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.schedule()
-        }
-    }
-
-}
-

--- a/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
+++ b/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
@@ -9,14 +9,24 @@ import SwiftUI
 import SwiftUIKitView
 
 struct SwiftUIwithUIKitView: View {
+    @State var integer: Int = 0
+
     var body: some View {
         NavigationView {
-            UIKitView() // <- This is a `UIKit` view.
-                .swiftUIView(layout: .intrinsic) // <- This is a SwiftUI `View`.
-                .set(\.title, to: "Hello, UIKit!")
-                .set(\.backgroundColor, to: UIColor(named: "swiftlee_orange"))
-                .fixedSize()
-                .navigationTitle("Use UIKit in SwiftUI")
+            VStack {
+//                UIViewMaker<UILabel> {
+//                    $0.text = "Hello no \(self.integer) from UIKit"
+//                }
+//                .fixedSize()
+                UIViewContainer(UIKitView(), layout: .intrinsic)
+                    .set(\.title, to: "Hello, UIKit \(integer)!")
+                    .set(\.backgroundColor, to: UIColor(named: "swiftlee_orange"))
+                    .fixedSize()
+                    .navigationTitle("Use UIKit in SwiftUI")
+                Button("RANDOMIZED: \(integer)") {
+                    integer = Int.random(in: 0..<300)
+                }
+            }
         }
     }
 }
@@ -37,5 +47,53 @@ struct UILabelExample_Preview: PreviewProvider {
             .previewLayout(.sizeThatFits)
             .previewDisplayName("UILabel Preview Example")
     }
+}
+
+struct UIViewMaker<ViewType: UIView>: UIViewRepresentable {
+
+    typealias UIViewType = ViewType
+
+    var make: () -> ViewType = ViewType.init
+    var update: (ViewType) -> ()
+
+    func makeUIView(context: Context) -> ViewType {
+        return make()
+    }
+
+    func updateUIView(_ uiView: ViewType, context: Context) {
+        update(uiView)
+    }
+}
+
+struct ContentView: View {
+    @State var counter = 0
+
+    var body: some View {
+        VStack {
+
+            Text("Hello no \(counter) from SwiftUI")
+                .padding()
+
+
+            UIViewMaker<UILabel> {
+                $0.text = "Hello no \(self.counter) from UIKit"
+            }
+            .fixedSize()
+
+        }
+        .onAppear {
+            if counter == 0 {
+                schedule()
+            }
+        }
+    }
+
+    func schedule() {
+        counter += 1
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.schedule()
+        }
+    }
+
 }
 

--- a/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
+++ b/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
@@ -18,9 +18,9 @@ struct SwiftUIwithUIKitView: View {
 //                    $0.text = "Hello no \(self.integer) from UIKit"
 //                }
 //                .fixedSize()
-                UIViewContainer(UILabel(), layout: .intrinsic)
-                    .set(\.text, to: "Hello, UIKit \(integer)!")
-                    .set(\.backgroundColor, to: UIColor(named: "swiftlee_orange"))
+//                UIViewContainer(UILabel(), layout: .intrinsic)
+//                    .set(\.text, to: "Hello, UIKit \(integer)!")
+//                    .set(\.backgroundColor, to: UIColor(named: "swiftlee_orange"))
 //                    .fixedSize()
                 UIViewContainer(UIKitView(), layout: .intrinsic)
                     .set(\.title, to: "Hello, UIKit \(integer)!")

--- a/Example/SwiftUIKitExample/UIKitView.swift
+++ b/Example/SwiftUIKitExample/UIKitView.swift
@@ -48,6 +48,8 @@ final class UIKitView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
+
+        print("INIT")
     }
     
     required init?(coder: NSCoder) {

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ import PackageDescription
 let package = Package(
     name: "SwiftUIKitView",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v14),
         .macOS(.v10_15),
-        .tvOS(.v13),
+        .tvOS(.v14),
         .watchOS(.v6)
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -12,18 +12,11 @@ let package = Package(
         .watchOS(.v6)
     ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "SwiftUIKitView",
             targets: ["SwiftUIKitView"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SwiftUIKitView",
             dependencies: []),

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SwiftUIKitView
-![Swift Version](https://img.shields.io/badge/Swift-5.3-F16D39.svg?style=flat) ![Dependency frameworks](https://img.shields.io/badge/Supports-_Swift_Package_Manager-F16D39.svg?style=flat) [![Twitter](https://img.shields.io/badge/twitter-@Twannl-blue.svg?style=flat)](https://twitter.com/twannl)
+![Swift Version](https://img.shields.io/badge/Swift-5.5-F16D39.svg?style=flat) ![Dependency frameworks](https://img.shields.io/badge/Supports-_Swift_Package_Manager-F16D39.svg?style=flat) [![Twitter](https://img.shields.io/badge/twitter-@Twannl-blue.svg?style=flat)](https://twitter.com/twannl)
 
 Easily use UIKit views in SwiftUI.
 
@@ -11,7 +11,14 @@ You can read more about [Getting started with UIKit in SwiftUI and visa versa](h
 
 ## Examples
 
-Using a `UIKit` view directly in SwiftUI:
+### Using SwiftUIKitView in Production Code
+Using a `UIKit` view directly in SwiftUI for production code requires you to use:
+
+```swift
+UIViewContainer(<YOUR UIKit View>, layout: <YOUR LAYOUT PREFERENCE>)
+```
+
+This is to prevent a UIKit view from being redrawn on every SwiftUI view redraw.
 
 ```swift
 import SwiftUI
@@ -20,8 +27,7 @@ import SwiftUIKitView
 struct SwiftUIwithUIKitView: View {
     var body: some View {
         NavigationView {
-            UILabel() // <- This can be any `UIKit` view.
-                .swiftUIView(layout: .intrinsic) // <- This is returning a SwiftUI `View`.
+            UIViewContainer(UILabel(), layout: .intrinsic) // <- This can be any `UIKit` view.
                 .set(\.text, to: "Hello, UIKit!") // <- Use key paths for updates.
                 .set(\.backgroundColor, to: UIColor(named: "swiftlee_orange"))
                 .fixedSize()
@@ -31,7 +37,16 @@ struct SwiftUIwithUIKitView: View {
 }
 ```
 
-Creating a preview provider for a `UIView`:
+### Using `SwiftUIKitView` in Previews
+Performance in Previews is less important, it's being redrawn either way.
+Therefore, you can use of the more convenient  `swiftUIView()` modifier:
+
+```swift
+UILabel() // <- This is a `UIKit` view.
+    .swiftUIView(layout: .intrinsic) // <- This is a SwiftUI `View`.
+```
+
+Creating a preview provider for a `UIView` looks as follows:
 
 ```swift
 import SwiftUI
@@ -96,7 +111,7 @@ Once you have your Swift package set up, adding the SDK as a dependency is as ea
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/AvdLee/SwiftUIKitView.git", .upToNextMajor(from: "1.0.0"))
+    .package(url: "https://github.com/AvdLee/SwiftUIKitView.git", .upToNextMajor(from: "2.0.0"))
 ]
 ```
 

--- a/Sources/SwiftUIKitView/IntrinsicContentView.swift
+++ b/Sources/SwiftUIKitView/IntrinsicContentView.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 final class IntrinsicContentView<ContentView: UIView>: UIView {
-    var contentView: ContentView
+    let contentView: ContentView
     let layout: Layout
 
     init(contentView: ContentView, layout: Layout) {
@@ -25,12 +25,19 @@ final class IntrinsicContentView<ContentView: UIView>: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private var contentHeight: CGFloat = .zero {
+    private var contentSize: CGSize = .zero {
         didSet { invalidateIntrinsicContentSize() }
     }
 
     override var intrinsicContentSize: CGSize {
-        .init(width: UIView.noIntrinsicMetric, height: contentHeight)
+        switch layout {
+        case .intrinsic:
+            return contentSize
+        case .fixedWidth(let width):
+            return .init(width: width, height: contentSize.height)
+        case .fixed(let size):
+            return size
+        }
     }
 
     override var frame: CGRect {
@@ -42,10 +49,10 @@ final class IntrinsicContentView<ContentView: UIView>: UIView {
 
             let targetSize = CGSize(width: frame.width, height: UIView.layoutFittingCompressedSize.height)
 
-            contentHeight = contentView.systemLayoutSizeFitting(
+            contentSize = contentView.systemLayoutSizeFitting(
                 targetSize,
                 withHorizontalFittingPriority: .required,
-                verticalFittingPriority: .fittingSizeLevel).height
+                verticalFittingPriority: .fittingSizeLevel)
         }
     }
 }

--- a/Sources/SwiftUIKitView/IntrinsicContentView.swift
+++ b/Sources/SwiftUIKitView/IntrinsicContentView.swift
@@ -1,0 +1,51 @@
+//
+//  IntrinsicContentView.swift
+//  
+//
+//  Created by Antoine van der Lee on 23/07/2022.
+//
+
+import Foundation
+import UIKit
+
+final class IntrinsicContentView<ContentView: UIView>: UIView {
+    var contentView: ContentView
+    let layout: Layout
+
+    init(contentView: ContentView, layout: Layout) {
+        self.contentView = contentView
+        self.layout = layout
+
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        addSubview(contentView)
+    }
+
+    @available(*, unavailable) required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private var contentHeight: CGFloat = .zero {
+        didSet { invalidateIntrinsicContentSize() }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        .init(width: UIView.noIntrinsicMetric, height: contentHeight)
+    }
+
+    override var frame: CGRect {
+        didSet {
+            guard frame != oldValue else { return }
+
+            contentView.frame = self.bounds
+            contentView.layoutIfNeeded()
+
+            let targetSize = CGSize(width: frame.width, height: UIView.layoutFittingCompressedSize.height)
+
+            contentHeight = contentView.systemLayoutSizeFitting(
+                targetSize,
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .fittingSizeLevel).height
+        }
+    }
+}

--- a/Sources/SwiftUIKitView/IntrinsicContentView.swift
+++ b/Sources/SwiftUIKitView/IntrinsicContentView.swift
@@ -29,7 +29,6 @@ public final class IntrinsicContentView<ContentView: UIView>: UIView {
     private var contentSize: CGSize = .zero {
         didSet {
             invalidateIntrinsicContentSize()
-            print(#function)
         }
     }
 
@@ -45,7 +44,6 @@ public final class IntrinsicContentView<ContentView: UIView>: UIView {
     }
 
     public func updateContentSize() {
-        print(#function)
         switch layout {
         case .fixedWidth(let width):
             // Set the frame of the cell, so that the layout can be updated.
@@ -66,46 +64,6 @@ public final class IntrinsicContentView<ContentView: UIView>: UIView {
             contentSize = size
         case .intrinsic:
             contentSize = contentView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-        }
-    }
-
-    public override var frame: CGRect {
-        didSet {
-            guard frame != oldValue || contentSize == .zero else {
-                return
-            }
-
-//            contentView.frame = self.bounds
-//            contentView.layoutIfNeeded()
-//
-//            let targetSize = CGSize(width: frame.width, height: UIView.layoutFittingCompressedSize.height)
-//
-//            contentSize = contentView.systemLayoutSizeFitting(
-//                targetSize,
-//                withHorizontalFittingPriority: .required,
-//                verticalFittingPriority: .fittingSizeLevel)
-
-//            switch layout {
-//            case .fixedWidth(let width):
-//                // Set the frame of the cell, so that the layout can be updated.
-//                var newFrame = contentView.frame
-//                newFrame.size = CGSize(width: width, height: UIView.layoutFittingExpandedSize.height)
-//                contentView.frame = newFrame
-//
-//                // Make sure the contents of the cell have the correct layout.
-//                contentView.setNeedsLayout()
-//                contentView.layoutIfNeeded()
-//
-//                // Get the size of the cell
-//                let computedSize = contentView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-//
-//                // Apple: "Only consider the height for cells, because the contentView isn't anchored correctly sometimes." We use ceil to make sure we get rounded numbers and no half pixels.
-//                contentSize = CGSize(width: width, height: ceil(computedSize.height))
-//            case .fixed(let size):
-//                contentSize = size
-//            case .intrinsic:
-//                contentSize = contentView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-//            }
         }
     }
 }

--- a/Sources/SwiftUIKitView/ModifiedUIViewContainer.swift
+++ b/Sources/SwiftUIKitView/ModifiedUIViewContainer.swift
@@ -1,0 +1,39 @@
+//
+//  ModifiedUIViewContainer.swift
+//  
+//
+//  Created by Antoine van der Lee on 23/07/2022.
+//
+
+import Foundation
+import SwiftUI
+import UIKit
+
+public struct ModifiedUIViewContainer<ChildContainer: UIViewContaining, Child, Value>: UIViewContaining where ChildContainer.Child == Child {
+
+    let child: ChildContainer
+    let keyPath: ReferenceWritableKeyPath<Child, Value>
+    let value: Value
+
+    public func makeCoordinator() -> UIViewContainingCoordinator<Child> {
+        child.makeCoordinator() as! UIViewContainingCoordinator<Child>
+    }
+
+    public func makeUIView(context: Context) -> IntrinsicContentView<Child> {
+        context.coordinator.createView()
+    }
+
+    public func updateUIView(_ uiView: IntrinsicContentView<Child>, context: Context) {
+        update(uiView.contentView, coordinator: context.coordinator, updateContentSize: true)
+    }
+
+    public func update(_ uiView: Child, coordinator: UIViewContainingCoordinator<Child>, updateContentSize: Bool) {
+        uiView[keyPath: keyPath] = value
+        child.update(uiView, coordinator: coordinator, updateContentSize: false)
+
+        if updateContentSize {
+            coordinator.view?.updateContentSize()
+        }
+    }
+}
+

--- a/Sources/SwiftUIKitView/SwiftUIViewConvertable.swift
+++ b/Sources/SwiftUIKitView/SwiftUIViewConvertable.swift
@@ -21,6 +21,10 @@ extension UIView: SwiftUIViewConvertable {}
 @available(iOS 13.0, *)
 public extension SwiftUIViewConvertable where Self: UIView {
     func swiftUIView(layout: Layout) -> UIViewContainer<Self> {
+        assert(
+            ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1",
+            "This method is designed to use in previews only and is not performant for production code. Use `UIViewContainer(<YOUR VIEW>, layout: layout)` instead."
+        )
         return UIViewContainer(self, layout: layout)
     }
 }

--- a/Sources/SwiftUIKitView/SwiftUIViewConvertable.swift
+++ b/Sources/SwiftUIKitView/SwiftUIViewConvertable.swift
@@ -12,7 +12,7 @@ import UIKit
 @available(iOS 13.0, *)
 public protocol SwiftUIViewConvertable {
     associatedtype View: UIView
-    func swiftUIView(layout: UIViewContainer<View>.Layout) -> UIViewContainer<View>
+    func swiftUIView(layout: Layout) -> UIViewContainer<View>
 }
 
 /// Add default protocol comformance for `UIView` instances.
@@ -20,7 +20,7 @@ extension UIView: SwiftUIViewConvertable {}
 
 @available(iOS 13.0, *)
 public extension SwiftUIViewConvertable where Self: UIView {
-    func swiftUIView(layout: UIViewContainer<Self>.Layout) -> UIViewContainer<Self> {
+    func swiftUIView(layout: Layout) -> UIViewContainer<Self> {
         return UIViewContainer(self, layout: layout)
     }
 }

--- a/Sources/SwiftUIKitView/UIViewContainer.swift
+++ b/Sources/SwiftUIKitView/UIViewContainer.swift
@@ -11,9 +11,9 @@ import SwiftUI
 
 /// A container for UIKit `UIView` elements. Conforms to the `UIViewRepresentable` protocol to allow conversion into SwiftUI `View`s.
 @available(iOS 13.0, *)
-public struct UIViewContainer<Child: UIView>: Identifiable {
+public struct UIViewContainer<Child: UIView> { //}: Identifiable {
     
-    public var id: UIView { view }
+//    public var id: UIView { view }
 
     /// The type of Layout to apply to the SwiftUI `View`.
     public enum Layout {
@@ -28,59 +28,52 @@ public struct UIViewContainer<Child: UIView>: Identifiable {
         case fixed(size: CGSize)
     }
     
-    private let view: Child
+//    var view: Child! {
+//        get { coordinator.view }
+//    }
+    private let viewCreator: () -> Child
     private let layout: Layout
-    
+
     /// - Returns: The `CGSize` to apply to the view.
-    private var size: CGSize {
-        switch layout {
-        case .fixedWidth(let width):
-            // Set the frame of the cell, so that the layout can be updated.
-            var newFrame = view.frame
-            newFrame.size = CGSize(width: width, height: UIView.layoutFittingExpandedSize.height)
-            view.frame = newFrame
-            
-            // Make sure the contents of the cell have the correct layout.
-            view.setNeedsLayout()
-            view.layoutIfNeeded()
-            
-            // Get the size of the cell
-            let computedSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-            
-            // Apple: "Only consider the height for cells, because the contentView isn't anchored correctly sometimes." We use ceil to make sure we get rounded numbers and no half pixels.
-            return CGSize(width: width, height: ceil(computedSize.height))
-        case .fixed(let size):
-            return size
-        case .intrinsic:
-            return view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-        }
-    }
+//    private var size: CGSize {
+//        switch layout {
+//        case .fixedWidth(let width):
+//            // Set the frame of the cell, so that the layout can be updated.
+//            var newFrame = view.frame
+//            newFrame.size = CGSize(width: width, height: UIView.layoutFittingExpandedSize.height)
+//            view.frame = newFrame
+//
+//            // Make sure the contents of the cell have the correct layout.
+//            view.setNeedsLayout()
+//            view.layoutIfNeeded()
+//
+//            // Get the size of the cell
+//            let computedSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+//
+//            // Apple: "Only consider the height for cells, because the contentView isn't anchored correctly sometimes." We use ceil to make sure we get rounded numbers and no half pixels.
+//            return CGSize(width: width, height: ceil(computedSize.height))
+//        case .fixed(let size):
+//            return size
+//        case .intrinsic:
+//            return view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+//        }
+//    }
     
     /// Initializes a `UIViewContainer`
     /// - Parameters:
     ///   - view: `UIView` being previewed
     ///   - layout: The layout to apply on the `UIView`. Defaults to `intrinsic`.
-    public init(_ view: @autoclosure () -> Child, layout: Layout = .intrinsic) {
-        self.view = view()
+    public init(_ view: @escaping @autoclosure () -> Child, layout: Layout = .intrinsic) {
+        self.viewCreator = view
         self.layout = layout
-        
-        switch layout {
-        case .intrinsic:
-            return
-        case .fixed(let size):
-            self.view.widthAnchor.constraint(equalToConstant: size.width).isActive = true
-            self.view.heightAnchor.constraint(equalToConstant: size.height).isActive = true
-        case .fixedWidth(let width):
-            self.view.widthAnchor.constraint(equalToConstant: width).isActive = true
-        }
     }
     
     /// Applies the correct size to the SwiftUI `View` container.
     /// - Returns: A `View` with the correct size applied.
-    public func fixedSize() -> some View {
-        let size = self.size
-        return frame(width: size.width, height: size.height, alignment: .topLeading)
-    }
+//    public func fixedSize() -> some View {
+//        let size = self.size
+//        return frame(width: size.width, height: size.height, alignment: .topLeading)
+//    }
     
     /// Creates a preview of the `UIViewContainer` with the right size applied.
     /// - Returns: A preview of the container.
@@ -89,18 +82,49 @@ public struct UIViewContainer<Child: UIView>: Identifiable {
             .previewLayout(.sizeThatFits)
             .previewDisplayName(displayName)
     }
+
+    public class Coordinator<Child> {
+        var view: Child!
+        var viewCreator: () -> Child
+        var modifiers: [(Child) -> Void] = []
+
+        init(_ viewCreator: @escaping () -> Child) {
+            self.viewCreator = viewCreator
+        }
+    }
 }
 
 // MARK: Preview + UIViewRepresentable
 
 @available(iOS 13, *)
 extension UIViewContainer: UIViewRepresentable {
+    public func makeCoordinator() -> Coordinator<Child> {
+        // Create an instance of Coordinator
+        return Coordinator(self.viewCreator)
+    }
 
-    public func makeUIView(context: Context) -> UIView {
-        return view
+    public func makeUIView(context: Context) -> Child {
+        context.coordinator.view = viewCreator()
+        context.coordinator.modifiers.forEach { modifier in
+            modifier(context.coordinator.view)
+        }
+        switch layout {
+        case .intrinsic:
+            return context.coordinator.view
+        case .fixed(let size):
+            context.coordinator.view.widthAnchor.constraint(equalToConstant: size.width).isActive = true
+            context.coordinator.view.heightAnchor.constraint(equalToConstant: size.height).isActive = true
+        case .fixedWidth(let width):
+            context.coordinator.view.widthAnchor.constraint(equalToConstant: width).isActive = true
+        }
+        return context.coordinator.view
     }
     
-    public func updateUIView(_ view: UIView, context: Context) {}
+    public func updateUIView(_ view: Child, context: Context) {
+        context.coordinator.modifiers.forEach { modifier in
+            modifier(view)
+        }
+    }
 }
 
 @available(iOS 13.0, *)
@@ -108,7 +132,10 @@ extension UIViewContainer: KeyPathReferenceWritable {
     public typealias T = Child
     
     public func set<Value>(_ keyPath: ReferenceWritableKeyPath<Child, Value>, to value: Value) -> Self {
-        view[keyPath: keyPath] = value
+        coordinator.modifiers.append({ view in
+            view[keyPath: keyPath] = value
+        })
+        print("Modifiers is now \(coordinator.modifiers)")
         return self
     }
 }

--- a/Sources/SwiftUIKitView/UIViewContainer.swift
+++ b/Sources/SwiftUIKitView/UIViewContainer.swift
@@ -9,94 +9,6 @@ import Foundation
 import UIKit
 import SwiftUI
 
-/// The type of Layout to apply to the SwiftUI `View`.
-public enum Layout {
-
-    /// Uses the size returned by .`systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)`.
-    case intrinsic
-
-    /// Uses an intrinsic height combined with a fixed width.
-    case fixedWidth(width: CGFloat)
-
-    /// A fixed width and height is used.
-    case fixed(size: CGSize)
-}
-
-public class UIViewContainingCoordinator<Child: UIView> {
-    private(set) var view: IntrinsicContentView<Child>?
-    private var viewCreator: () -> Child
-
-    var widthConstraint: NSLayoutConstraint?
-    var heightConstraint: NSLayoutConstraint?
-    private let layout: Layout
-
-    init(_ viewCreator: @escaping () -> Child, layout: Layout) {
-        self.viewCreator = viewCreator
-        self.layout = layout
-    }
-
-    func createView() {
-        guard view == nil else { return }
-        let contentView = viewCreator()
-        view = IntrinsicContentView(contentView: contentView, layout: layout)
-    }
-
-    func updateSize(for view: Child) {
-//        switch layout {
-//        case .intrinsic:
-//            break
-//        case .fixed(let size):
-//            update(view: view, width: size.width, height: size.height)
-//        case .fixedWidth(let width):
-//            update(view: view, width: width, height: nil)
-//        }
-    }
-
-    private func update(view: Child, width: CGFloat?, height: CGFloat?) {
-        if let width = width {
-            if let widthConstraint = widthConstraint {
-                widthConstraint.constant = width
-            } else {
-                widthConstraint = view.widthAnchor.constraint(equalToConstant: width)
-                widthConstraint?.isActive = true
-            }
-        }
-        if let height = height {
-            if let heightConstraint = heightConstraint {
-                heightConstraint.constant = height
-            } else {
-                heightConstraint = view.heightAnchor.constraint(equalToConstant: height)
-                heightConstraint?.isActive = true
-            }
-        }
-    }
-
-    /// - Returns: The `CGSize` to apply to the view.
-    func size(for view: Child) -> CGSize {
-        switch layout {
-        case .fixedWidth(let width):
-            // Set the frame of the cell, so that the layout can be updated.
-            var newFrame = view.frame
-            newFrame.size = CGSize(width: width, height: UIView.layoutFittingExpandedSize.height)
-            view.frame = newFrame
-
-            // Make sure the contents of the cell have the correct layout.
-            view.setNeedsLayout()
-            view.layoutIfNeeded()
-
-            // Get the size of the cell
-            let computedSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-
-            // Apple: "Only consider the height for cells, because the contentView isn't anchored correctly sometimes." We use ceil to make sure we get rounded numbers and no half pixels.
-            return CGSize(width: width, height: ceil(computedSize.height))
-        case .fixed(let size):
-            return size
-        case .intrinsic:
-            return view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-        }
-    }
-}
-
 /// A container for UIKit `UIView` elements. Conforms to the `UIViewRepresentable` protocol to allow conversion into SwiftUI `View`s.
 @available(iOS 13.0, *)
 public struct UIViewContainer<Child: UIView> {
@@ -124,95 +36,18 @@ extension UIViewContainer: UIViewRepresentable {
     }
 
     public func makeUIView(context: Context) -> IntrinsicContentView<Child> {
-        print("MAKE VIEW")
         context.coordinator.createView()
-        return context.coordinator.view!
     }
     
     public func updateUIView(_ view: IntrinsicContentView<Child>, context: Context) {
-        print("UPDATE VIEW")
         update(view.contentView, coordinator: context.coordinator, updateContentSize: true)
 
     }
+}
 
+extension UIViewContainer: UIViewContaining {
     public func update(_ uiView: Child, coordinator: UIViewContainingCoordinator<Child>, updateContentSize: Bool) {
-        print("UPDATE UIViewContainer")
-        uiView.setContentHuggingPriority(.defaultHigh, for: .vertical)
-        uiView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        coordinator.updateSize(for: uiView)
-        print(uiView.intrinsicContentSize)
-    }
-}
-
-public protocol UIViewContaining: UIViewRepresentable {
-    associatedtype Child: UIView
-    func set<Value>(_ keyPath: ReferenceWritableKeyPath<Child, Value>, to value: Value) -> ModifiedUIViewContainer<Self, Child, Value>
-    func update(_ uiView: Child, coordinator: UIViewContainingCoordinator<Child>, updateContentSize: Bool)
-}
-
-extension UIViewContaining {
-    public func set<Value>(_ keyPath: ReferenceWritableKeyPath<Child, Value>, to value: Value) -> ModifiedUIViewContainer<Self, Child, Value> {
-        ModifiedUIViewContainer(child: self, keyPath: keyPath, value: value)
-    }
-
-//    public func fixedSize() -> some View
-//    {
-//        print("FIXED SIZE")
-//        return self.background(Color.blue)
-//    }
-
-    /// Applies the correct size to the SwiftUI `View` container.
-    /// - Returns: A `View` with the correct size applied.
-//    public func fixedSizing() -> some View {
-//        if let view = coordinator.view {
-//            update(coordinator.view!)
-//            let size = coordinator.size(for: view)
-//            return self.frame(width: size.width, height: size.height, alignment: .topLeading)
-//        } else {
-//            return self
-//        }
-//    }
-
-}
-
-public extension View {
-    /// Creates a preview of the `UIViewContainer` with the right size applied.
-    /// - Returns: A preview of the container.
-    func preview(displayName: String? = nil) -> some View {
-        return fixedSize()
-            .previewLayout(.sizeThatFits)
-            .previewDisplayName(displayName)
-    }
-}
-
-extension UIViewContainer: UIViewContaining { }
-public struct ModifiedUIViewContainer<ChildContainer: UIViewContaining, Child, Value>: UIViewContaining where ChildContainer.Child == Child {
-    var child: ChildContainer
-
-    @State var keyPath: ReferenceWritableKeyPath<Child, Value>
-    @State var value: Value
-
-    public func makeCoordinator() -> UIViewContainingCoordinator<Child> {
-        child.makeCoordinator() as! UIViewContainingCoordinator<Child>
-    }
-
-    public func makeUIView(context: Context) -> IntrinsicContentView<Child> {
-        context.coordinator.createView()
-        return context.coordinator.view!
-    }
-
-    public func updateUIView(_ uiView: IntrinsicContentView<Child>, context: Context) {
-        update(uiView.contentView, coordinator: context.coordinator, updateContentSize: true)
-    }
-
-    public func update(_ uiView: Child, coordinator: UIViewContainingCoordinator<Child>, updateContentSize: Bool) {
-        print("UPDATE Modified \(keyPath)")
-        uiView[keyPath: keyPath] = value
-        child.update(uiView, coordinator: coordinator, updateContentSize: false)
-        coordinator.updateSize(for: uiView)
-
-        if updateContentSize {
-            coordinator.view?.updateContentSize()
-        }
+        guard updateContentSize else { return }
+        coordinator.view?.updateContentSize()
     }
 }

--- a/Sources/SwiftUIKitView/UIViewContainer.swift
+++ b/Sources/SwiftUIKitView/UIViewContainer.swift
@@ -9,6 +9,86 @@ import Foundation
 import UIKit
 import SwiftUI
 
+public class UIViewContainingCoordinator<Child: UIView> {
+    private(set) var view: Child?
+    private var viewCreator: () -> Child
+
+    var widthConstraint: NSLayoutConstraint?
+    var heightConstraint: NSLayoutConstraint?
+    private let layout: UIViewContainer<Child>.Layout
+
+    init(_ viewCreator: @escaping () -> Child, layout: UIViewContainer<Child>.Layout) {
+        self.viewCreator = viewCreator
+        self.layout = layout
+    }
+
+    func createView() {
+        guard view == nil else { return }
+        view = viewCreator()
+        view?.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    func updateSize(for view: Child) {
+        switch layout {
+        case .intrinsic:
+            let size = self.size(for: view)
+            update(view: view, width: size.width, height: size.height)
+        case .fixed(let size):
+            update(view: view, width: size.width, height: size.height)
+        case .fixedWidth(let width):
+            update(view: view, width: width, height: nil)
+        }
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        view.setNeedsUpdateConstraints()
+        view.updateConstraints()
+    }
+
+    private func update(view: Child, width: CGFloat?, height: CGFloat?) {
+        if let width = width {
+            if let widthConstraint = widthConstraint {
+                widthConstraint.constant = width
+            } else {
+                widthConstraint = view.widthAnchor.constraint(equalToConstant: width)
+                widthConstraint?.isActive = true
+            }
+        }
+        if let height = height {
+            if let heightConstraint = heightConstraint {
+                heightConstraint.constant = height
+            } else {
+                heightConstraint = view.heightAnchor.constraint(equalToConstant: height)
+                heightConstraint?.isActive = true
+            }
+        }
+    }
+
+    /// - Returns: The `CGSize` to apply to the view.
+    func size(for view: Child) -> CGSize {
+        switch layout {
+        case .fixedWidth(let width):
+            // Set the frame of the cell, so that the layout can be updated.
+            var newFrame = view.frame
+            newFrame.size = CGSize(width: width, height: UIView.layoutFittingExpandedSize.height)
+            view.frame = newFrame
+
+            // Make sure the contents of the cell have the correct layout.
+            view.setNeedsLayout()
+            view.layoutIfNeeded()
+
+            // Get the size of the cell
+            let computedSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+
+            // Apple: "Only consider the height for cells, because the contentView isn't anchored correctly sometimes." We use ceil to make sure we get rounded numbers and no half pixels.
+            return CGSize(width: width, height: ceil(computedSize.height))
+        case .fixed(let size):
+            return size
+        case .intrinsic:
+            return view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        }
+    }
+}
+
 /// A container for UIKit `UIView` elements. Conforms to the `UIViewRepresentable` protocol to allow conversion into SwiftUI `View`s.
 @available(iOS 13.0, *)
 public struct UIViewContainer<Child: UIView> { //}: Identifiable {
@@ -27,72 +107,15 @@ public struct UIViewContainer<Child: UIView> { //}: Identifiable {
         /// A fixed width and height is used.
         case fixed(size: CGSize)
     }
-    
-    var view: Child! {
-        get { coordinator.view }
-    }
-    private let viewCreator: () -> Child
-    private let layout: Layout
-    private let coordinator: Coordinator<Child>
 
-    /// - Returns: The `CGSize` to apply to the view.
-    private var size: CGSize {
-        switch layout {
-        case .fixedWidth(let width):
-            // Set the frame of the cell, so that the layout can be updated.
-            var newFrame = view.frame
-            newFrame.size = CGSize(width: width, height: UIView.layoutFittingExpandedSize.height)
-            view.frame = newFrame
-            
-            // Make sure the contents of the cell have the correct layout.
-            view.setNeedsLayout()
-            view.layoutIfNeeded()
-            
-            // Get the size of the cell
-            let computedSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-            
-            // Apple: "Only consider the height for cells, because the contentView isn't anchored correctly sometimes." We use ceil to make sure we get rounded numbers and no half pixels.
-            return CGSize(width: width, height: ceil(computedSize.height))
-        case .fixed(let size):
-            return size
-        case .intrinsic:
-            return view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-        }
-    }
+    @State public var coordinator: UIViewContainingCoordinator<Child>
     
     /// Initializes a `UIViewContainer`
     /// - Parameters:
     ///   - view: `UIView` being previewed
     ///   - layout: The layout to apply on the `UIView`. Defaults to `intrinsic`.
-    public init(_ view: @escaping @autoclosure () -> Child, layout: Layout = .intrinsic) {
-        self.viewCreator = view
-        self.layout = layout
-        self.coordinator = Coordinator(self.viewCreator)
-    }
-    
-    /// Applies the correct size to the SwiftUI `View` container.
-    /// - Returns: A `View` with the correct size applied.
-//    public func fixedSize() -> some View {
-//        let size = self.size
-//        return frame(width: size.width, height: size.height, alignment: .topLeading)
-//    }
-    
-    /// Creates a preview of the `UIViewContainer` with the right size applied.
-    /// - Returns: A preview of the container.
-    public func preview(displayName: String? = nil) -> some View {
-        return fixedSize()
-            .previewLayout(.sizeThatFits)
-            .previewDisplayName(displayName)
-    }
-
-    public class Coordinator<Child> {
-        var view: Child!
-        var viewCreator: () -> Child
-        var modifiers: [(Child) -> Void] = []
-
-        init(_ viewCreator: @escaping () -> Child) {
-            self.viewCreator = viewCreator
-        }
+    public init(_ viewCreator: @escaping @autoclosure () -> Child, layout: Layout = .intrinsic) {
+        self.coordinator = UIViewContainingCoordinator(viewCreator, layout: layout)
     }
 }
 
@@ -100,44 +123,88 @@ public struct UIViewContainer<Child: UIView> { //}: Identifiable {
 
 @available(iOS 13, *)
 extension UIViewContainer: UIViewRepresentable {
-    public func makeCoordinator() -> Coordinator<Child> {
+    public func makeCoordinator() -> UIViewContainingCoordinator<Child> {
         // Create an instance of Coordinator
         coordinator
     }
 
     public func makeUIView(context: Context) -> Child {
-        self.coordinator.view = viewCreator()
-        coordinator.modifiers.forEach { modifier in
-            modifier(self.coordinator.view)
-        }
-        switch layout {
-        case .intrinsic:
-            return view
-        case .fixed(let size):
-            self.view.widthAnchor.constraint(equalToConstant: size.width).isActive = true
-            self.view.heightAnchor.constraint(equalToConstant: size.height).isActive = true
-        case .fixedWidth(let width):
-            self.view.widthAnchor.constraint(equalToConstant: width).isActive = true
-        }
-        return view
+        context.coordinator.createView()
+        return context.coordinator.view!
     }
     
     public func updateUIView(_ view: Child, context: Context) {
-        coordinator.modifiers.forEach { modifier in
-            modifier(view)
-        }
+        update(view)
+        view.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    }
+
+    public func update(_ uiView: Child) {
+        coordinator.updateSize(for: uiView)
     }
 }
 
-@available(iOS 13.0, *)
-extension UIViewContainer: KeyPathReferenceWritable {
-    public typealias T = Child
-    
-    public func set<Value>(_ keyPath: ReferenceWritableKeyPath<Child, Value>, to value: Value) -> Self {
-        coordinator.modifiers.append({ view in
-            view[keyPath: keyPath] = value
-        })
-        print("Modifiers is now \(coordinator.modifiers)")
-        return self
+public protocol UIViewContaining: UIViewRepresentable {
+    associatedtype Child: UIView
+    var coordinator: UIViewContainingCoordinator<Child> { get }
+    func set<Value>(_ keyPath: ReferenceWritableKeyPath<Child, Value>, to value: Value) -> ModifiedUIViewContainer<Self, Child, Value>
+    func update(_ uiView: Child)
+}
+
+extension UIViewContaining {
+    public func set<Value>(_ keyPath: ReferenceWritableKeyPath<Child, Value>, to value: Value) -> ModifiedUIViewContainer<Self, Child, Value> {
+        ModifiedUIViewContainer(child: self, keyPath: keyPath, value: value)
+    }
+
+    /// Applies the correct size to the SwiftUI `View` container.
+    /// - Returns: A `View` with the correct size applied.
+//    public func fixedSizing() -> some View {
+//        if let view = coordinator.view {
+//            update(coordinator.view!)
+//            let size = coordinator.size(for: view)
+//            return self.frame(width: size.width, height: size.height, alignment: .topLeading)
+//        } else {
+//            return self
+//        }
+//    }
+
+}
+
+public extension View {
+    /// Creates a preview of the `UIViewContainer` with the right size applied.
+    /// - Returns: A preview of the container.
+    func preview(displayName: String? = nil) -> some View {
+        return fixedSize()
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName(displayName)
+    }
+}
+
+extension UIViewContainer: UIViewContaining { }
+public struct ModifiedUIViewContainer<ChildContainer: UIViewContaining, Child, Value>: UIViewContaining where ChildContainer.Child == Child {
+    var child: ChildContainer
+    public var coordinator: UIViewContainingCoordinator<Child> {
+        child.coordinator
+    }
+    @State var keyPath: ReferenceWritableKeyPath<Child, Value>
+    @State var value: Value
+
+    public func makeCoordinator() -> UIViewContainingCoordinator<Child> {
+        coordinator
+    }
+
+    public func makeUIView(context: Context) -> Child {
+        coordinator.createView()
+        return coordinator.view!
+    }
+
+    public func updateUIView(_ uiView: Child, context: Context) {
+        update(uiView)
+    }
+
+    public func update(_ uiView: Child) {
+        uiView[keyPath: keyPath] = value
+        child.update(uiView)
+        coordinator.updateSize(for: uiView)
     }
 }

--- a/Sources/SwiftUIKitView/UIViewContaining.swift
+++ b/Sources/SwiftUIKitView/UIViewContaining.swift
@@ -1,0 +1,32 @@
+//
+//  UIViewContaining.swift
+//  
+//
+//  Created by Antoine van der Lee on 23/07/2022.
+//
+
+import Foundation
+import UIKit
+import SwiftUI
+
+public protocol UIViewContaining: UIViewRepresentable {
+    associatedtype Child: UIView
+    func set<Value>(_ keyPath: ReferenceWritableKeyPath<Child, Value>, to value: Value) -> ModifiedUIViewContainer<Self, Child, Value>
+    func update(_ uiView: Child, coordinator: UIViewContainingCoordinator<Child>, updateContentSize: Bool)
+}
+
+extension UIViewContaining {
+    public func set<Value>(_ keyPath: ReferenceWritableKeyPath<Child, Value>, to value: Value) -> ModifiedUIViewContainer<Self, Child, Value> {
+        ModifiedUIViewContainer(child: self, keyPath: keyPath, value: value)
+    }
+}
+
+public extension View {
+    /// Creates a preview of the `UIViewContainer` with the right size applied.
+    /// - Returns: A preview of the container.
+    func preview(displayName: String? = nil) -> some View {
+        return fixedSize()
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName(displayName)
+    }
+}

--- a/Sources/SwiftUIKitView/UIViewContainingCoordinator.swift
+++ b/Sources/SwiftUIKitView/UIViewContainingCoordinator.swift
@@ -1,0 +1,47 @@
+//
+//  UIViewContainingCoordinator.swift
+//  
+//
+//  Created by Antoine van der Lee on 23/07/2022.
+//
+
+import Foundation
+import UIKit
+import SwiftUI
+
+/// The type of Layout to apply to the SwiftUI `View`.
+public enum Layout {
+
+    /// Uses the size returned by .`systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)`.
+    case intrinsic
+
+    /// Uses an intrinsic height combined with a fixed width.
+    case fixedWidth(width: CGFloat)
+
+    /// A fixed width and height is used.
+    case fixed(size: CGSize)
+}
+
+public class UIViewContainingCoordinator<Child: UIView> {
+    private(set) var view: IntrinsicContentView<Child>?
+    private var viewCreator: () -> Child
+
+    var widthConstraint: NSLayoutConstraint?
+    var heightConstraint: NSLayoutConstraint?
+    private let layout: Layout
+
+    init(_ viewCreator: @escaping () -> Child, layout: Layout) {
+        self.viewCreator = viewCreator
+        self.layout = layout
+    }
+
+    func createView() -> IntrinsicContentView<Child> {
+        if let view = view {
+            return view
+        } else {
+            let contentView = IntrinsicContentView(contentView: viewCreator(), layout: layout)
+            view = contentView
+            return contentView
+        }
+    }
+}


### PR DESCRIPTION
I initially built `SwiftUIKitView` to create previews for UIKit views quickly. Though, many started using this framework in production code, for which it was not optimized.

Code changes in this PR do optimize for production, making it easier to use UIKit views in production apps.

Fixes #2
Fixes #3