### PR TITLE
Added dynamicMemberLookup support

### DIFF
--- a/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
+++ b/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
@@ -40,7 +40,7 @@ struct UILabelExample_Preview: PreviewProvider {
     static var previews: some View {
         UILabel() // <- This is a `UIKit` view.
             .swiftUIView(layout: .intrinsic) // <- This is a SwiftUI `View`.
-            .text("Hello, UIKit!") // <- Use key paths for updates.
+            .text("Hello, UIKit!") // <- Set UIView properties as if they were SwiftUI properties
             .fixedSize() // <- Make sure the size is set
             .previewLayout(.sizeThatFits)
             .previewDisplayName("UILabel Preview Example")

--- a/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
+++ b/Example/SwiftUIKitExample/SwiftUIwithUIKitView.swift
@@ -16,8 +16,8 @@ struct SwiftUIwithUIKitView: View {
             VStack {
                 // Use UIKit inside SwiftUI like this:
                 UIViewContainer(UIKitView(), layout: .intrinsic)
-                    .set(\.title, to: "Hello, UIKit \(integer)!")
-                    .set(\.backgroundColor, to: UIColor(named: "swiftlee_orange"))
+                    .title("Hello, UIKit \(integer)!")
+                    .backgroundColor(UIColor(named: "swiftlee_orange"))
                     .fixedSize()
                     .navigationTitle("Use UIKit in SwiftUI")
 
@@ -40,7 +40,7 @@ struct UILabelExample_Preview: PreviewProvider {
     static var previews: some View {
         UILabel() // <- This is a `UIKit` view.
             .swiftUIView(layout: .intrinsic) // <- This is a SwiftUI `View`.
-            .set(\.text, to: "Hello, UIKit!") // <- Use key paths for updates.
+            .text("Hello, UIKit!") // <- Use key paths for updates.
             .fixedSize() // <- Make sure the size is set
             .previewLayout(.sizeThatFits)
             .previewDisplayName("UILabel Preview Example")

--- a/Example/SwiftUIKitExample/UIKitView.swift
+++ b/Example/SwiftUIKitExample/UIKitView.swift
@@ -13,7 +13,7 @@ struct UIKitView_Previews: PreviewProvider {
     static var previews: some View {
         UIKitView()
             .swiftUIView(layout: .intrinsic)
-            .set(\.title, to: "This is a UIView")
+            .title("This is a UIView")
             .preview(displayName: "A UIKit UIView preview")
     }
 }

--- a/Sources/SwiftUIKitView/ModifiedUIViewContainer.swift
+++ b/Sources/SwiftUIKitView/ModifiedUIViewContainer.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftUI
 import UIKit
 
+@dynamicMemberLookup
 public struct ModifiedUIViewContainer<ChildContainer: UIViewContaining, Child, Value>: UIViewContaining where ChildContainer.Child == Child {
 
     let child: ChildContainer
@@ -34,6 +35,10 @@ public struct ModifiedUIViewContainer<ChildContainer: UIViewContaining, Child, V
         if updateContentSize {
             coordinator.view?.updateContentSize()
         }
+    }
+    
+    public subscript<Value>(dynamicMember keyPath: ReferenceWritableKeyPath<Child, Value>) -> (Value) -> ModifiedUIViewContainer<Self, Child, Value> {
+        { self.set(keyPath, to: $0) }
     }
 }
 

--- a/Sources/SwiftUIKitView/UIViewContainer.swift
+++ b/Sources/SwiftUIKitView/UIViewContainer.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 /// A container for UIKit `UIView` elements. Conforms to the `UIViewRepresentable` protocol to allow conversion into SwiftUI `View`s.
 @available(iOS 13.0, *)
+@dynamicMemberLookup
 public struct UIViewContainer<Child: UIView> {
 
     let viewCreator: () -> Child
@@ -23,6 +24,10 @@ public struct UIViewContainer<Child: UIView> {
     public init(_ viewCreator: @escaping @autoclosure () -> Child, layout: Layout = .intrinsic) {
         self.viewCreator = viewCreator
         self.layout = layout
+    }
+    
+    public subscript<Value>(dynamicMember keyPath: ReferenceWritableKeyPath<Child, Value>) -> (Value) -> ModifiedUIViewContainer<Self, Child, Value> {
+        { self.set(keyPath, to: $0) }
     }
 }
 


### PR DESCRIPTION
This PR leverages `dynamicMemberLookup` to allow setting properties in the same style as SwiftUI.

Unfortunately DML cannot be implemented by a protocol so the implementation needs to be duplicated between the conforming types (`UIViewContainer` and `ModifiedUIViewContainer`)
